### PR TITLE
using Printf, using Compat.Printf

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,3 @@
 julia 0.7
 FFTW
-Printf
 SpecialFunctions


### PR DESCRIPTION
When add Package, I encounter the following problem. Solved by remove printf in REQUIRE.

https://discourse.julialang.org/t/using-printf/12919