### PR TITLE
Fix spin polarized PW functional

### DIFF
--- a/src/XC_funcs/XC_c_pw_spin.jl
+++ b/src/XC_funcs/XC_c_pw_spin.jl
@@ -91,14 +91,14 @@ function XC_c_pw_spin( Rhoe, zeta )
     fz = ( (1.0 + zeta)^(4.0/3.0) + (1.0 - zeta)^(4.0/3.0) - 2.0) / (2.0^(4.0/3.0) - 2.0)
     dfz = ( (1.0 + zeta)^(1.0/3.0) - (1.0 - zeta)^(1.0/3.0) ) * 4.0 / (3.0 * (2.0^(4.0/3.0) - 2.0) )
   
-    ec = epwc + alpha * fz * (1.0 - zeta4) / fz0 + (epwcp - epwc) * fz * zeta4
+    ec = epwc - alpha * fz * (1.0 - zeta4) / fz0 + (epwcp - epwc) * fz * zeta4
   
-    vcup = vpwc + vpwca * fz * (1.0 - zeta4) / fz0 + (vpwcp - vpwc)*fz*zeta4 +
-           (alpha / fz0 * (dfz * (1.0 - zeta4) - 4.0*fz*zeta3) +
+    vcup = vpwc - vpwca * fz * (1.0 - zeta4) / fz0 + (vpwcp - vpwc)*fz*zeta4 +
+           (-alpha / fz0 * (dfz * (1.0 - zeta4) - 4.0*fz*zeta3) +
            (epwcp - epwc) * (dfz * zeta4 + 4.0 * fz * zeta3) ) * (1.0 - zeta)
 
-    vcdw = vpwc + vpwca * fz * (1.0 - zeta4) / fz0 + (vpwcp - vpwc) * fz * zeta4 -
-          (alpha / fz0 * (dfz * (1.0 - zeta4) - 4.0 * fz * zeta3) +
+    vcdw = vpwc - vpwca * fz * (1.0 - zeta4) / fz0 + (vpwcp - vpwc) * fz * zeta4 -
+          (-alpha / fz0 * (dfz * (1.0 - zeta4) - 4.0 * fz * zeta3) +
             (epwcp - epwc) * (dfz * zeta4 + 4.0 * fz * zeta3) ) * (1.0 + zeta)
 
     return ec, vcup, vcdw

--- a/src/XC_funcs/XC_c_pw_spin_E.jl
+++ b/src/XC_funcs/XC_c_pw_spin_E.jl
@@ -75,7 +75,7 @@ function XC_c_pw_spin_E( Rhoe, zeta )
   
     fz = ( (1.0 + zeta)^(4.0/3.0) + (1.0 - zeta)^(4.0/3.0) - 2.0) / (2.0^(4.0/3.0) - 2.0)
   
-    ec = epwc + alpha * fz * (1.0 - zeta4) / fz0 + (epwcp - epwc) * fz * zeta4
+    ec = epwc - alpha * fz * (1.0 - zeta4) / fz0 + (epwcp - epwc) * fz * zeta4
 
     return ec
 end


### PR DESCRIPTION
* The PW spin interpolation parametrizes -alpha instead of alpha
  See here: https://gitlab.com/libxc/libxc/-/blob/master/maple/lda_exc/lda_c_pw.mpl#L40
* This is hidden in the original paper in Sec. II, best seen in Tab. I
  It took me a while to see it...: https://journals.aps.org/prb/pdf/10.1103/PhysRevB.45.13244
* Adjust the sign for alpha, and for the derivative
* I found this after translating this part to python and comparing it one-to-one with LibXC